### PR TITLE
Added : Dynamic ap name feature 

### DIFF
--- a/components/wifiManager/CMakeLists.txt
+++ b/components/wifiManager/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRC_DIRS Src
                     INCLUDE_DIRS Inc
-                    REQUIRES nvs_flash esp_http_server esp_wifi esp_netif esp_event esp_eth lwip esp_timer
+                    REQUIRES nvs_flash esp_http_server esp_wifi esp_netif esp_event esp_eth lwip esp_timer efuse
 										EMBED_FILES Web/index.html Web/scan.css Web/app.js Web/password.html Web/password.css Web/password.js 
 															Web/lib/jquery-3.3.1.min.js  #!TODO: Change to minified version of EMBED_FILES 
 															Web/icons/favicon.ico Web/icons/wifi_full.ico Web/icons/wifi_three.ico 

--- a/components/wifiManager/Kconfig
+++ b/components/wifiManager/Kconfig
@@ -116,6 +116,12 @@ menu "WifiManager Configuration"
 
 	menu "AP Configuration"
 
+		config USE_DYNAMIC_AP_NAME
+			bool "Use Dynamic AP"
+			default n
+			help
+				Enable to use dynamic AP Name configuration. This naming will be based on the MAC address of the ESP32.
+
 		config WIFI_AP_SSID
 			string "SSID for AP"
 			default "ESP32_WM_AP"

--- a/components/wifiManager/Src/wm_wifi.c
+++ b/components/wifiManager/Src/wm_wifi.c
@@ -12,6 +12,9 @@
 #include "esp_netif.h"
 #include "esp_wifi_netif.h"
 #include "lwip/netdb.h"
+#include "esp_efuse.h"
+#include "nvs_flash.h"
+#include "esp_mac.h"
 
 #include "wifiManager_private.h"
 #include "wm_generalMacros.h"
@@ -427,17 +430,29 @@ static esp_err_t wm_wifi_connect_sta(wifi_config_t *wifi_config_params)
 */
 static void wm_wifi_connect_apsta(void)
 {
-		wifi_config_t wifi_ap_config = {
-			.ap = {
-					.ssid = WIFI_AP_SSID,
-					.password = WIFI_AP_PASS,
-					.channel = WIFI_AP_CHANNEL,
-					.ssid_hidden = WIFI_AP_SSID_HIDDEN,
-					.max_connection = WIFI_AP_MAX_CONNECTIONS,
-					.beacon_interval = WIFI_AP_BEACON_INTERVAL,
-					.authmode = WIFI_AUTH_WPA_WPA2_PSK
-			}
+	uint8_t mac[6];  // Array to hold the MAC address
+	esp_err_t result = esp_efuse_mac_get_default(mac);  // Retrieve the MAC address
+
+	if (result != ESP_OK) {
+			printf("Failed to get MAC address\n");
+	}
+
+	wifi_config_t wifi_ap_config = {
+		.ap = {
+				.ssid = WIFI_AP_SSID,
+				.password = WIFI_AP_PASS,
+				.channel = WIFI_AP_CHANNEL,
+				.ssid_hidden = WIFI_AP_SSID_HIDDEN,
+				.max_connection = WIFI_AP_MAX_CONNECTIONS,
+				.beacon_interval = WIFI_AP_BEACON_INTERVAL,
+				.authmode = WIFI_AUTH_WPA_WPA2_PSK
+		}
 	};
+
+	snprintf((char *)wifi_ap_config.ap.ssid + strlen((char *)wifi_ap_config.ap.ssid), 
+					sizeof(wifi_ap_config.ap.ssid) - strlen((char *)wifi_ap_config.ap.ssid), 
+					"%02X%02X%02X%02X%02X%02X",
+					mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
 	if (strlen((char *)wifi_ap_config.ap.password) == 0) {
 			wifi_ap_config.ap.authmode = WIFI_AUTH_OPEN;

--- a/components/wifiManager/Src/wm_wifi.c
+++ b/components/wifiManager/Src/wm_wifi.c
@@ -12,9 +12,9 @@
 #include "esp_netif.h"
 #include "esp_wifi_netif.h"
 #include "lwip/netdb.h"
-#include "esp_efuse.h"
-#include "nvs_flash.h"
+#ifdef CONFIG_USE_DYNAMIC_AP_NAME
 #include "esp_mac.h"
+#endif
 
 #include "wifiManager_private.h"
 #include "wm_generalMacros.h"
@@ -430,12 +430,14 @@ static esp_err_t wm_wifi_connect_sta(wifi_config_t *wifi_config_params)
 */
 static void wm_wifi_connect_apsta(void)
 {
+#ifdef CONFIG_USE_DYNAMIC_AP_NAME
 	uint8_t mac[6];  // Array to hold the MAC address
 	esp_err_t result = esp_efuse_mac_get_default(mac);  // Retrieve the MAC address
 
 	if (result != ESP_OK) {
 			printf("Failed to get MAC address\n");
 	}
+#endif
 
 	wifi_config_t wifi_ap_config = {
 		.ap = {
@@ -449,10 +451,12 @@ static void wm_wifi_connect_apsta(void)
 		}
 	};
 
+#ifdef CONFIG_USE_DYNAMIC_AP_NAME
 	snprintf((char *)wifi_ap_config.ap.ssid + strlen((char *)wifi_ap_config.ap.ssid), 
 					sizeof(wifi_ap_config.ap.ssid) - strlen((char *)wifi_ap_config.ap.ssid), 
 					"%02X%02X%02X%02X%02X%02X",
 					mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+#endif
 
 	if (strlen((char *)wifi_ap_config.ap.password) == 0) {
 			wifi_ap_config.ap.authmode = WIFI_AUTH_OPEN;


### PR DESCRIPTION
Dynamic AP name usage. 
This means the AP names of the device are unique due to esp32's unique MAC address property with a prefix. 
- Choosable, you can select  __USE_DYNAMIC_AP_NAME__ from menuconfig.
- The default, this feature is disabled.